### PR TITLE
Fix the ISO image authenticity verification

### DIFF
--- a/_includes/media/media_image.md
+++ b/_includes/media/media_image.md
@@ -53,8 +53,14 @@ The success of one of these commands confirms that your ISO image was properly d
 
 Replace the name of the file accordingly
 
+#### ARCH LINUX
 ```
-$ gpg --keyserver-options auto-key-retrieve --verify archlinux-year.month.day-x86_64.iso.sig
+pacman-key -v archlinux-year.month.day-x86_64.iso.sig
+```
+
+#### OTHERS
+```
+$ gpg --keyserver-options auto-key-retrieve --keyserver pool.sks-keyservers.net --verify archlinux-year.month.day-x86_64.iso.sig
 ```
 
 ### References
@@ -64,8 +70,9 @@ $ gpg --keyserver-options auto-key-retrieve --verify archlinux-year.month.day-x8
 1. [Wikipedia - Cheksum](https://en.wikipedia.org/wiki/Checksum)
 1. [Wikipedia - Digital signature](https://en.wikipedia.org/wiki/Digital_signature)
 1. [ArchWiki - Installation guide](https://wiki.archlinux.org/index.php/Installation_guide#Verify_signature)
-1. [ArchWiki - GnuPG](https://wiki.archlinux.org/index.php/GnuPG)
+1. [ArchWiki - GnuPG](https://wiki.archlinux.org/index.php/GnuPG#Use_a_keyserver)
 1. [ManPage - Md5sum](https://jlk.fjfi.cvut.cz/arch/manpages/man/core/coreutils/md5sum.1.en)
 1. [ManPage - Sha1sum](https://jlk.fjfi.cvut.cz/arch/manpages/man/core/coreutils/sha1sum.1.en)
 1. [ManPage - Gpg](https://jlk.fjfi.cvut.cz/arch/manpages/man/core/gnupg/gpg.1.en)
+1. [SKS keyservers](https://sks-keyservers.net/)
 {: .fs-3}


### PR DESCRIPTION
### Changelog

- Add a command to verify the authenticity of the ISO image from Arch Linux.
- Add a command to verify the authenticity of the ISO image from other distributions.