### PR TITLE
Move the location of the run guide in the wiki section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 	</p>
 	<p>
 		<a href="https://chaosdynamix.github.io/Arcadia/">
-			<img src="https://img.shields.io/badge/-Show the guide-blue?style=for-the-badge" alt="Guide page link" />
+			<img src="https://img.shields.io/badge/-Show the website-blue?style=for-the-badge" alt="Website page link" />
 		</a>
 	</p>
 </div>
@@ -15,26 +15,13 @@
 	</p>
 </div>
 
----
-
-### Run the project
-
-1. Install the dependencies : `docker` and `make`.
-1. Clone the repository in the folder of your choice with : `git clone https://github.com/ChaosDynamix/Arcadia.git`.
-1. Move to the project directory : `cd Arcadia`.
-1. Create the docker image : `make image`.
-1. Run the temporary docker container : `make container`.
-1. Open your browser at the address : `http://0.0.0.0:4000/Arcadia`.
-
-#### Alternative
-
-You can also run the project **without** docker :
-
-1. Install the dependencies : `ruby`, `rubygems`, `gcc` and `make`.
-1. Install bundler : `gem install bundler`.
-1. Clone the repository in the folder of your choice with : `git clone https://github.com/ChaosDynamix/Arcadia.git`.
-1. Move to the project directory : `cd Arcadia`.
-1. Install the gems : `bundle install`
-1. Launch jekyll : `bundle exec jekyll serve`.
-1. Open your browser at the address : `http://0.0.0.0:4000/Arcadia`.
-
+<div align="center">
+	<h2>How to run the project</h2>
+	<p>Arcadia is a Jekyll project running with or without docker. A guide is available in wiki section of this repository. 
+	</p>
+	<p>
+		<a href="https://github.com/ChaosDynamix/Arcadia/wiki">
+			<img src="https://img.shields.io/badge/-Show the guide-blue?style=for-the-badge" alt="Guide page link" />
+		</a>
+	</p>
+</div>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center" style="margin-bottom: 32px;">
+<div align="center" height="200px">
 	<h1>Arcadia</h1>
 	<p>Arcadia is a website that presents several scenarios for installing Arch Linux on LUKS with LVM and EXT4.
 	</p>
@@ -9,7 +9,7 @@
 	</p>
 </div>
 
-<div align="center" style="margin-bottom: 24px;">
+<div align="center">
 	<h2>This project is in early stage</h2>
 	<p>Please do not  follow the guide for the moment until this section disappear. The guide will not work or will be incomplete. Use it at your own risk.
 	</p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center" height="200px">
+<div align="center">
 	<h1>Arcadia</h1>
 	<p>Arcadia is a website that presents several scenarios for installing Arch Linux on LUKS with LVM and EXT4.
 	</p>
@@ -7,6 +7,7 @@
 			<img src="https://img.shields.io/badge/-Show the website-blue?style=for-the-badge" alt="Website page link" />
 		</a>
 	</p>
+	<p>---</p>
 </div>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" style="margin-bottom: 32px;">
 	<h1>Arcadia</h1>
 	<p>Arcadia is a website that presents several scenarios for installing Arch Linux on LUKS with LVM and EXT4.
 	</p>
@@ -9,15 +9,11 @@
 	</p>
 </div>
 
----
-
-<div align="center">
+<div align="center" style="margin-bottom: 24px;">
 	<h2>This project is in early stage</h2>
 	<p>Please do not  follow the guide for the moment until this section disappear. The guide will not work or will be incomplete. Use it at your own risk.
 	</p>
 </div>
-
----
 
 <div align="center">
 	<h2>How to run the project</h2>

--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@
 	</p>
 </div>
 
+---
+
 <div align="center">
 	<h2>This project is in early stage</h2>
 	<p>Please do not  follow the guide for the moment until this section disappear. The guide will not work or will be incomplete. Use it at your own risk.
 	</p>
 </div>
+
+---
 
 <div align="center">
 	<h2>How to run the project</h2>


### PR DESCRIPTION
### Changelog
- Create a CTA for the run guide that link to the wiki section in the README.md file.
- Remove the run guide from the README.md file.

### Actions
close #28 