### PR TITLE
guide(archlinux): index page display wrong privilege elevation app

### DIFF
--- a/guides/arch-linux/index.md
+++ b/guides/arch-linux/index.md
@@ -33,4 +33,4 @@ Arch Linux is an independently developed, x86-64 general-purpose GNU/Linux distr
 | Initialization manager | Systemd          |
 | Network manager        | Systemd-networkd |
 | Boot manager           | Systemd-boot     |
-| Privilege elevation    | Opendoas         |
+| Privilege elevation    | Sudo             |


### PR DESCRIPTION
### Changelog
- Replace the privilege elevation program in the system components table
of the index page (Opendoas -> Sudo).

### Actions
close #65 