### PR TITLE
(docker) bump github pages gem to 214

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:2.7.3
 
 RUN bundle config --global frozen 1
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+SHELL = /bin/sh
+
+LOCAL_PORT = 4000
+LOCAL_DIR = $(shell pwd)
+DOCKER_HOST = 0.0.0.0
+DOCKER_PORT = 4000
+DOCKER_DIR = /usr/src/app
+DOCKER_IMG_RUBY = ruby:2.7.3
+DOCKER_IMG_GHPAGES = gh-pages:214
+
+# Launch command as recipes
+.PHONY: gemfile_lock image container
+
+# Generate Ruby Gemfile.lock
+gemfile_lock:
+	docker run --rm \
+               --volume $(LOCAL_DIR):$(DOCKER_DIR) \
+               --workdir $(DOCKER_DIR) \
+               $(DOCKER_IMG_RUBY) \
+               bundle install
+
+# Build Docker image
+image:
+	docker build --tag $(DOCKER_IMG_GHPAGES) .
+
+# Start Docker container
+container:
+	docker run --rm \
+               --volume $(LOCAL_DIR):$(DOCKER_DIR) \
+               --publish $(LOCAL_PORT):$(DOCKER_PORT) \
+               $(DOCKER_IMG_GHPAGES) \
+               bundle exec jekyll serve --host $(DOCKER_HOST) --port $(DOCKER_PORT)

--- a/README.md
+++ b/README.md
@@ -14,28 +14,4 @@
 <div align="center">
     <h2>Caution</h2>
     <p>This project should be used at your own risk, always check the official documentation and the provided sources when using this guide.</p>
-    <p>---</p>
-</div>
-
-<!-- How to run the project section -->
-<div align="center">
-    <h2>How to run the project</h2>
-    <p>Arcadia use Jekyll to run the project. A guide for docker is available in the wiki section of this repository. You can also run the project without docker by installing jekyll directly on your system.</p>
-    <p>
-        <a href="https://github.com/ChaosDynamix/Arcadia/wiki/How-to-run-the-project">
-            <img src="https://img.shields.io/badge/-Show the guide-blue?style=for-the-badge" alt="How to run the project - wiki link" />
-        </a>
-    </p>
-    <p>---</p>
-</div>
-
-<!-- How to contribute section -->
-<div align="center">
-    <h2>How to contribute</h2>
-    <p>If you want to contribute to the project, make sure to follow the simple rules given by the wiki in order to keep a good organization, clarity and consistency in the repository.</p>
-    <p>
-        <a href="https://github.com/ChaosDynamix/Arcadia/wiki/How-to-contribute">
-            <img src="https://img.shields.io/badge/-Show the rules-blue?style=for-the-badge" alt="How to contribute - wiki link" />
-        </a>
-    </p>
 </div>


### PR DESCRIPTION
# Docker project
This pull request will affect the Docker Github project.

## What are the sections affected ?
- :x: Ruby
    - :x: Configuration
    - :heavy_check_mark: Gems
- :x: Jekyll
    - :x: Configuration
    - :x: Pages
    - :x: Includes
    - :x: Layouts
    - :x: Data
- :heavy_check_mark: Docker

## What is the current behavior ?
Issue number: #111 

## What is the new behavior ?
- Update Gemfile and Gemfile.lock
- Creat Makefile for running the project.

## Actions
close #111