### PR TITLE
docs(repo): fix issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,16 +16,16 @@ assignees: ChaosDynamix
 ### Description
 A clear and concise description of the problem...
 
-## Exception or error message
+### Exception or error message
 ```
 paste the message here...
 ```
 
-## Environment
+### Environment
 - **Operating system**:
 - **Platform(s)**:
 - **Package(s)**
 
-## Branches
+### Branches
 - Working branch: `<username>/description`
 - Origin branch: `master`

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,4 +28,4 @@ paste the message here...
 
 ## Branches
 - Working branch: `<username>/description`
-- Origin branch: `main`
+- Origin branch: `master`

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,8 @@ assignees: ChaosDynamix
 
 ### Affected section(s)
 - :heavy_check_mark: Build system
+- :x: Documentation
 - :x: Website
-- :x: Repository
 
 ### Description
 A clear and concise description of the problem...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,8 +10,8 @@ assignees: ChaosDynamix
 
 ### Relevant section(s)
 - :heavy_check_mark: Build system
+- :x: Documentation
 - :x: Website
-- :x: Repository
 
 ### Description
 A clear and concise description of the problem or missing documentation and/or capability...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -24,4 +24,4 @@ Have you considered any alternative solutions or workarounds?
 
 ### Branches
 - Working branch: `<username>/description`
-- Origin branch: `main`
+- Origin branch: `master`

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -19,4 +19,4 @@ A clear and concise description of the problem...
 
 ### Branches
 - Working branch: `<username>/description`
-- Origin branch: `main`
+- Origin branch: `master`

--- a/.github/ISSUE_TEMPLATE/update_report.md
+++ b/.github/ISSUE_TEMPLATE/update_report.md
@@ -21,4 +21,4 @@ A new version is available for the packages:
 
 ### Branches
 - Working branch: `<username>/description`
-- Origin branch: `main`
+- Origin branch: `master`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,7 @@
 ## Pull request type
-- :heavy_check_mark: Feature
-- :x: Fix
-- :x: Build
-- :x: Refactoring
+- :heavy_check_mark: Build system
 - :x: Documentation
-- :x: Guide
+- :x: Website
 
 ## What is the current behavior ?
 issue number: #


### PR DESCRIPTION
## Pull request type
- :x: Build system
- :heavy_check_mark: Documentation
- :x: Website

## What is the current behavior ?
issue number: #115

## What is the new behavior ?
- Change the origin branch for the issue templates (main -> master)
- Modify the affected sections of the issue and pull request templates as follow
    1. Build system
    1. Documentation
    1. Website
- Fix the heading levels of the sections in the bug issue template (H2 -> h3)

## Fixed issues
close #115